### PR TITLE
Updating rubocop.yml to fix throwed error working with Ruby 2.7 and Rails 6.

### DIFF
--- a/ror/.rubocop.yml
+++ b/ror/.rubocop.yml
@@ -41,7 +41,7 @@ Style/DefWithParentheses:
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: key
 Layout/ExtraSpacing:
   AllowForAlignment: false


### PR DESCRIPTION
Error: The `Layout/AlignHash` cop has been renamed to `Layout/HashAlignment`.
(obsolete configuration found in .rubocop.yml, please update it)